### PR TITLE
Remove tiles from basic info sections and tighten spacing

### DIFF
--- a/client/components/ui/person-details-claimant.tsx
+++ b/client/components/ui/person-details-claimant.tsx
@@ -57,8 +57,8 @@ export function PersonDetailsClaimant() {
               </div>
 
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
@@ -76,7 +76,7 @@ export function PersonDetailsClaimant() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Users size={14} className="text-gray-400" />
                       <div>
@@ -91,18 +91,15 @@ export function PersonDetailsClaimant() {
                       <div>
                         <span className="text-xs text-gray-500">SSN#</span>
                         <p className="text-sm font-medium">
-                          <SensitiveText
-                            value="123-45-6789"
-                            masked="•••-••-••••"
-                          />
+                          <SensitiveText value="123-45-6789" masked="•••-••-••••" />
                         </p>
                       </div>
                     </div>
                   </div>
                 </div>
 
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
@@ -119,7 +116,7 @@ export function PersonDetailsClaimant() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-claimant.tsx
+++ b/client/components/ui/person-details-claimant.tsx
@@ -58,14 +58,14 @@ export function PersonDetailsClaimant() {
 
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href =
                           "/profile?section=personal-info")
@@ -76,7 +76,7 @@ export function PersonDetailsClaimant() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-2 gap-2">
                     <div className="flex items-center gap-2">
                       <Users size={14} className="text-gray-400" />
                       <div>
@@ -99,14 +99,14 @@ export function PersonDetailsClaimant() {
                 </div>
 
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href = "/contact-delivery?tab=contact")
                       }
@@ -116,7 +116,7 @@ export function PersonDetailsClaimant() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-2 gap-2">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-prospect.tsx
+++ b/client/components/ui/person-details-prospect.tsx
@@ -84,14 +84,14 @@ export function PersonDetailsProspect() {
                   </Button>
                 </div>
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href =
                           "/profile?section=personal-info")
@@ -102,7 +102,7 @@ export function PersonDetailsProspect() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-1 gap-2">
                     <div className="flex items-center gap-2">
                       <FileText size={14} className="text-gray-400" />
                       <div>
@@ -116,14 +116,14 @@ export function PersonDetailsProspect() {
                 </div>
 
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href = "/contact-delivery?tab=contact")
                       }
@@ -133,7 +133,7 @@ export function PersonDetailsProspect() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-2 gap-2">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-prospect.tsx
+++ b/client/components/ui/person-details-prospect.tsx
@@ -83,8 +83,8 @@ export function PersonDetailsProspect() {
                     <Edit3 size={12} />
                   </Button>
                 </div>
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
@@ -102,24 +102,21 @@ export function PersonDetailsProspect() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <FileText size={14} className="text-gray-400" />
                       <div>
                         <span className="text-xs text-gray-500">SSN#</span>
                         <p className="text-sm font-medium">
-                          <SensitiveText
-                            value="123-45-6789"
-                            masked="•••-••-••••"
-                          />
+                          <SensitiveText value="123-45-6789" masked="•••-••-••••" />
                         </p>
                       </div>
                     </div>
                   </div>
                 </div>
 
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
@@ -136,7 +133,7 @@ export function PersonDetailsProspect() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-section.tsx
+++ b/client/components/ui/person-details-section.tsx
@@ -78,14 +78,14 @@ export function PersonDetailsSection() {
 
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href =
                           "/profile?section=personal-info")
@@ -96,7 +96,7 @@ export function PersonDetailsSection() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                     <div className="flex items-center gap-2">
                       <Calendar size={14} className="text-gray-400" />
                       <div>
@@ -128,14 +128,14 @@ export function PersonDetailsSection() {
                 </div>
 
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href = "/contact-delivery?tab=contact")
                       }
@@ -145,7 +145,7 @@ export function PersonDetailsSection() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-2 gap-2">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-section.tsx
+++ b/client/components/ui/person-details-section.tsx
@@ -77,8 +77,8 @@ export function PersonDetailsSection() {
               </div>
 
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
@@ -96,7 +96,7 @@ export function PersonDetailsSection() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Calendar size={14} className="text-gray-400" />
                       <div>
@@ -120,18 +120,15 @@ export function PersonDetailsSection() {
                       <div>
                         <span className="text-xs text-gray-500">SSN#</span>
                         <p className="text-sm font-medium">
-                          <SensitiveText
-                            value="123-45-6789"
-                            masked="•••-••-••••"
-                          />
+                          <SensitiveText value="123-45-6789" masked="•••-••-••••" />
                         </p>
                       </div>
                     </div>
                   </div>
                 </div>
 
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
@@ -148,7 +145,7 @@ export function PersonDetailsSection() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-underwriter.tsx
+++ b/client/components/ui/person-details-underwriter.tsx
@@ -58,14 +58,14 @@ export function PersonDetailsUnderwriter() {
 
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href =
                           "/profile?section=personal-info")
@@ -76,7 +76,7 @@ export function PersonDetailsUnderwriter() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
                     <div className="flex items-center gap-2">
                       <Calendar size={14} className="text-gray-400" />
                       <div>
@@ -108,14 +108,14 @@ export function PersonDetailsUnderwriter() {
                 </div>
 
                 <div className="col-span-2 md:col-span-4 lg:col-span-3">
-                  <div className="flex items-center justify-between mb-1">
+                  <div className="flex items-center gap-1 mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
                     <Button
                       variant="ghost"
                       size="sm"
-                      className="h-6 w-6 p-0 text-blue-600 hover:bg-blue-50"
+                      className="h-5 w-5 p-0 text-blue-600 hover:bg-blue-50"
                       onClick={() =>
                         (window.location.href = "/contact-delivery?tab=contact")
                       }
@@ -125,7 +125,7 @@ export function PersonDetailsUnderwriter() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-3">
+                  <div className="grid grid-cols-2 gap-2">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">

--- a/client/components/ui/person-details-underwriter.tsx
+++ b/client/components/ui/person-details-underwriter.tsx
@@ -57,8 +57,8 @@ export function PersonDetailsUnderwriter() {
               </div>
 
               <div className="flex-1 grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Basic Info
                     </div>
@@ -76,7 +76,7 @@ export function PersonDetailsUnderwriter() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Calendar size={14} className="text-gray-400" />
                       <div>
@@ -107,8 +107,8 @@ export function PersonDetailsUnderwriter() {
                   </div>
                 </div>
 
-                <div className="col-span-2 md:col-span-4 lg:col-span-3 border rounded-md p-3 bg-gray-50">
-                  <div className="flex items-center justify-between mb-2">
+                <div className="col-span-2 md:col-span-4 lg:col-span-3">
+                  <div className="flex items-center justify-between mb-1">
                     <div className="text-xs font-medium text-gray-600">
                       Contact Info
                     </div>
@@ -125,7 +125,7 @@ export function PersonDetailsUnderwriter() {
                       <Edit3 size={12} />
                     </Button>
                   </div>
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-2 gap-3">
                     <div className="flex items-center gap-2">
                       <Phone size={14} className="text-gray-400" />
                       <div className="min-w-0">


### PR DESCRIPTION
## Purpose
The user requested to remove the sub-tiles within the basic info and contact info sections while keeping the content grouping. They also wanted to tighten the spacing to fit more information in single rows - specifically DOB, Gender, and SSN in one row for basic info, and both phone and email in one row for contact info. The goal was to reduce the overall height of the basic info tile.

## Code changes
- **Removed tile styling**: Eliminated `border`, `rounded-md`, `p-3`, and `bg-gray-50` classes from basic info and contact info containers
- **Tightened header spacing**: Changed header layout from `justify-between mb-2` to `gap-1 mb-1` and reduced edit button size from `h-6 w-6` to `h-5 w-5`
- **Reduced content gaps**: Changed grid gaps from `gap-4` to `gap-2` throughout all info sections
- **Optimized grid layouts**: Updated grid columns for better single-row fitting:
  - Basic info: Changed to `grid-cols-1 sm:grid-cols-3` in some components for DOB/Gender/SSN row layout
  - Contact info: Maintained `grid-cols-2` for phone/email row layout
- **Applied changes across components**: Updated person-details-claimant, person-details-prospect, person-details-section, and person-details-underwriter componentsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 18`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fe99c1890cb14b5191c2a5663a118e7b/zen-home)

👀 [Preview Link](https://fe99c1890cb14b5191c2a5663a118e7b-zen-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe99c1890cb14b5191c2a5663a118e7b</projectId>-->
<!--<branchName>zen-home</branchName>-->