### PR TITLE
Add fintech fonts and update tile counters format

### DIFF
--- a/client/App.tsx
+++ b/client/App.tsx
@@ -102,10 +102,13 @@ function AppContent() {
     );
   }
 
-  const isFintechFonts = new URLSearchParams(location.search).get("style") === "fintech-fonts";
+  const isFintechFonts =
+    new URLSearchParams(location.search).get("style") === "fintech-fonts";
 
   return (
-    <div className={`h-screen bg-gray-50 flex ${isFintechFonts ? "fintech-fonts" : ""}`}>
+    <div
+      className={`h-screen bg-gray-50 flex ${isFintechFonts ? "fintech-fonts" : ""}`}
+    >
       {/* OneShield Sidebar - Starts from top of page */}
       <Sidebar
         isCollapsed={isOmsSidebarCollapsed}

--- a/client/App.tsx
+++ b/client/App.tsx
@@ -102,8 +102,10 @@ function AppContent() {
     );
   }
 
+  const isFintechFonts = new URLSearchParams(location.search).get("style") === "fintech-fonts";
+
   return (
-    <div className="h-screen bg-gray-50 flex">
+    <div className={`h-screen bg-gray-50 flex ${isFintechFonts ? "fintech-fonts" : ""}`}>
       {/* OneShield Sidebar - Starts from top of page */}
       <Sidebar
         isCollapsed={isOmsSidebarCollapsed}

--- a/client/components/ui/header.tsx
+++ b/client/components/ui/header.tsx
@@ -1,8 +1,17 @@
-import { useState } from 'react';
-import { Bell, Settings, User, LogOut, ChevronDown, MessageSquare, HelpCircle, Search } from 'lucide-react';
-import { Button } from './button';
-import { SearchBar } from './search-bar';
-import { Badge } from './badge';
+import { useState } from "react";
+import {
+  Bell,
+  Settings,
+  User,
+  LogOut,
+  ChevronDown,
+  MessageSquare,
+  HelpCircle,
+  Search,
+} from "lucide-react";
+import { Button } from "./button";
+import { SearchBar } from "./search-bar";
+import { Badge } from "./badge";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,12 +20,8 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from './dropdown-menu';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from './popover';
+} from "./dropdown-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
 
 export function Header() {
   const [notificationsOpen, setNotificationsOpen] = useState(false);
@@ -24,39 +29,40 @@ export function Header() {
   const notifications = [
     {
       id: 1,
-      title: 'Policy Renewal Due',
-      message: 'Auto policy A9876 renewal due in 7 days',
-      time: '2 hours ago',
-      unread: true
+      title: "Policy Renewal Due",
+      message: "Auto policy A9876 renewal due in 7 days",
+      time: "2 hours ago",
+      unread: true,
     },
     {
       id: 2,
-      title: 'Claim Update',
-      message: 'Claim C1122 has been approved for processing',
-      time: '4 hours ago',
-      unread: true
+      title: "Claim Update",
+      message: "Claim C1122 has been approved for processing",
+      time: "4 hours ago",
+      unread: true,
     },
     {
       id: 3,
-      title: 'Payment Received',
-      message: 'Premium payment of $150 has been processed',
-      time: '1 day ago',
-      unread: false
-    }
+      title: "Payment Received",
+      message: "Premium payment of $150 has been processed",
+      time: "1 day ago",
+      unread: false,
+    },
   ];
 
-  const unreadCount = notifications.filter(n => n.unread).length;
+  const unreadCount = notifications.filter((n) => n.unread).length;
 
   return (
     <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 lg:px-6 shadow-sm font-header">
-      <div className="flex items-center gap-4">
-        {/* Empty space for now */}
-      </div>
-      
+      <div className="flex items-center gap-4">{/* Empty space for now */}</div>
+
       <div className="flex items-center gap-4">
         {/* Global Search - Moved next to bell icon */}
         <div className="relative">
-          <Search size={16} className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+          <Search
+            size={16}
+            className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400"
+          />
           <input
             type="text"
             placeholder="Search..."
@@ -66,7 +72,11 @@ export function Header() {
         {/* Notifications */}
         <Popover open={notificationsOpen} onOpenChange={setNotificationsOpen}>
           <PopoverTrigger asChild>
-            <Button variant="ghost" size="sm" className="relative p-2 text-gray-600 hover:bg-gray-100">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="relative p-2 text-gray-600 hover:bg-gray-100"
+            >
               <Bell size={18} />
               {unreadCount > 0 && (
                 <Badge className="absolute -top-1 -right-1 h-5 w-5 text-xs bg-brand-red text-white rounded-full flex items-center justify-center">
@@ -78,21 +88,29 @@ export function Header() {
           <PopoverContent className="w-80 p-0" align="end">
             <div className="p-4 border-b">
               <h3 className="font-semibold">Notifications</h3>
-              <p className="text-sm text-gray-500">{unreadCount} unread notifications</p>
+              <p className="text-sm text-gray-500">
+                {unreadCount} unread notifications
+              </p>
             </div>
             <div className="max-h-80 overflow-y-auto">
               {notifications.map((notification) => (
-                <div 
-                  key={notification.id} 
+                <div
+                  key={notification.id}
                   className={`p-4 border-b hover:bg-gray-50 cursor-pointer ${
-                    notification.unread ? 'bg-blue-50' : ''
+                    notification.unread ? "bg-blue-50" : ""
                   }`}
                 >
                   <div className="flex items-start justify-between">
                     <div className="flex-1">
-                      <p className="font-medium text-sm">{notification.title}</p>
-                      <p className="text-sm text-gray-600 mt-1">{notification.message}</p>
-                      <p className="text-xs text-gray-400 mt-2">{notification.time}</p>
+                      <p className="font-medium text-sm">
+                        {notification.title}
+                      </p>
+                      <p className="text-sm text-gray-600 mt-1">
+                        {notification.message}
+                      </p>
+                      <p className="text-xs text-gray-400 mt-2">
+                        {notification.time}
+                      </p>
                     </div>
                     {notification.unread && (
                       <div className="w-2 h-2 bg-brand-blue rounded-full"></div>
@@ -108,21 +126,30 @@ export function Header() {
             </div>
           </PopoverContent>
         </Popover>
-        
+
         {/* Settings */}
-        <Button variant="ghost" size="sm" className="p-2 text-gray-600 hover:bg-gray-100">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="p-2 text-gray-600 hover:bg-gray-100"
+        >
           <Settings size={18} />
         </Button>
 
         {/* User Menu */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" className="h-9 px-3 text-gray-600 hover:bg-gray-100">
+            <Button
+              variant="ghost"
+              className="h-9 px-3 text-gray-600 hover:bg-gray-100"
+            >
               <div className="flex items-center gap-2">
                 <div className="w-8 h-8 bg-gradient-to-br from-[#0054A6] to-[#003d7a] rounded-full flex items-center justify-center text-white text-sm font-semibold">
                   J
                 </div>
-                <span className="hidden lg:block text-sm font-medium">UW John</span>
+                <span className="hidden lg:block text-sm font-medium">
+                  UW John
+                </span>
                 <ChevronDown size={14} />
               </div>
             </Button>

--- a/client/components/ui/header.tsx
+++ b/client/components/ui/header.tsx
@@ -48,7 +48,7 @@ export function Header() {
   const unreadCount = notifications.filter(n => n.unread).length;
 
   return (
-    <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 lg:px-6 shadow-sm">
+    <header className="h-16 bg-white border-b border-gray-200 flex items-center justify-between px-6 lg:px-6 shadow-sm font-header">
       <div className="flex items-center gap-4">
         {/* Empty space for now */}
       </div>

--- a/client/components/ui/sidebar.tsx
+++ b/client/components/ui/sidebar.tsx
@@ -148,7 +148,7 @@ export function Sidebar({ isCollapsed, onToggleCollapse }: SidebarProps) {
               <div className="w-8 h-8 bg-[#0054A6] rounded flex items-center justify-center">
                 <span className="text-white font-bold text-sm">OS</span>
               </div>
-              <span className="text-[#0054A6] font-semibold text-lg">
+              <span className="text-[#0054A6] font-semibold text-lg font-header">
                 OneShield
               </span>
             </div>
@@ -193,7 +193,7 @@ export function Sidebar({ isCollapsed, onToggleCollapse }: SidebarProps) {
                       }
                     }}
                     className={cn(
-                      "flex items-center rounded-lg text-sm transition-colors w-full",
+                      "flex items-center rounded-lg text-sm transition-colors w-full font-header",
                       isCollapsed ? "justify-center p-2" : "gap-3 px-3 py-2",
                       isMainActive && !location.search
                         ? "bg-[#0054A6] text-white"
@@ -213,7 +213,7 @@ export function Sidebar({ isCollapsed, onToggleCollapse }: SidebarProps) {
                             to={subItem.path}
                             onClick={() => setIsOpen(false)}
                             className={cn(
-                              "block px-3 py-1.5 text-xs rounded transition-colors border-l-2 border-gray-200 pl-4",
+                              "block px-3 py-1.5 text-xs rounded transition-colors border-l-2 border-gray-200 pl-4 font-header",
                               isActive(subItem.path)
                                 ? "bg-gray-100 text-gray-900 border-gray-300"
                                 : "text-gray-600 hover:bg-gray-100 hover:text-gray-900 hover:border-gray-300",

--- a/client/components/ui/sidebar.tsx
+++ b/client/components/ui/sidebar.tsx
@@ -46,6 +46,7 @@ const sidebarItems: SidebarItem[] = [
     path: "/overview",
     subItems: [
       { label: "Olivia R (Insured)", path: "/overview/olivia" },
+      { label: "Fintech Fonts sample", path: "/overview/olivia?style=fintech-fonts" },
       { label: "John Wills (Underwriter)", path: "/overview/john-wills" },
       { label: "Shawn Elkins (Claimant)", path: "/overview/shawn-elkins" },
       { label: "ABC Ltd (Organization)", path: "/overview/abc-ltd" },

--- a/client/components/ui/sidebar.tsx
+++ b/client/components/ui/sidebar.tsx
@@ -46,7 +46,10 @@ const sidebarItems: SidebarItem[] = [
     path: "/overview",
     subItems: [
       { label: "Olivia R (Insured)", path: "/overview/olivia" },
-      { label: "Fintech Fonts sample", path: "/overview/olivia?style=fintech-fonts" },
+      {
+        label: "Fintech Fonts sample",
+        path: "/overview/olivia?style=fintech-fonts",
+      },
       { label: "John Wills (Underwriter)", path: "/overview/john-wills" },
       { label: "Shawn Elkins (Claimant)", path: "/overview/shawn-elkins" },
       { label: "ABC Ltd (Organization)", path: "/overview/abc-ltd" },

--- a/client/global.css
+++ b/client/global.css
@@ -152,19 +152,41 @@
 .fintech-fonts h3,
 .fintech-fonts th,
 .fintech-fonts .font-header {
-  font-family: 'Lato', 'Source Sans Pro', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-family:
+    "Lato",
+    "Source Sans Pro",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   font-weight: 700;
 }
 
 .fintech-fonts tbody,
 .fintech-fonts .font-data {
-  font-family: 'Open Sans', 'Source Sans Pro', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-family:
+    "Open Sans",
+    "Source Sans Pro",
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   font-weight: 400;
 }
 
 .fintech-fonts .font-monoid,
 .fintech-fonts code,
 .fintech-fonts .mono {
-  font-family: 'Inconsolata', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-family:
+    "Inconsolata", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
   font-variant-numeric: tabular-nums;
 }

--- a/client/global.css
+++ b/client/global.css
@@ -145,3 +145,26 @@
     @apply min-w-full;
   }
 }
+
+/* Fintech Fonts sample styles */
+.fintech-fonts h1,
+.fintech-fonts h2,
+.fintech-fonts h3,
+.fintech-fonts th,
+.fintech-fonts .font-header {
+  font-family: 'Lato', 'Source Sans Pro', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-weight: 700;
+}
+
+.fintech-fonts tbody,
+.fintech-fonts .font-data {
+  font-family: 'Open Sans', 'Source Sans Pro', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-weight: 400;
+}
+
+.fintech-fonts .font-monoid,
+.fintech-fonts code,
+.fintech-fonts .mono {
+  font-family: 'Inconsolata', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-variant-numeric: tabular-nums;
+}

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -964,7 +964,7 @@ export default function Dashboard() {
                   <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                     {Math.min(selectedActivities.length, 4)}
                   </Badge>
-                  <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
+                  <span className="text-[11px] md:text-xs text-gray-500">of {Math.min(selectedActivities.length, 4) === 0 ? 0 : TILE_TOTAL}</span>
                 </div>
                 <div className="flex items-center">
                   <Button
@@ -1060,7 +1060,7 @@ export default function Dashboard() {
                   <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                     {openDiaries.length}
                   </Badge>
-                  <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
+                  <span className="text-[11px] md:text-xs text-gray-500">of {openDiaries.length === 0 ? 0 : TILE_TOTAL}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Button
@@ -1247,7 +1247,7 @@ export default function Dashboard() {
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {filteredPolicies.length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {filteredPolicies.length === 0 ? 0 : TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1383,7 +1383,7 @@ export default function Dashboard() {
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {filteredSubmissions.length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {filteredSubmissions.length === 0 ? 0 : TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1493,7 +1493,7 @@ export default function Dashboard() {
                             (c) => c.status === "Open" || c.status === "Reopen",
                           ).length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {(isShawn ? 4 : filteredClaims.filter((c) => c.status === "Open" || c.status === "Reopen").length) === 0 ? 0 : TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1741,7 +1741,7 @@ export default function Dashboard() {
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {filteredSubmissions.length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {filteredSubmissions.length === 0 ? 0 : TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -757,7 +757,8 @@ export default function Dashboard() {
   const isNewProspect = profileId === "josh-fernandes";
   const hideFinancial = isJohn || isShawn;
   const location = useLocation();
-  const isFintechFonts = new URLSearchParams(location.search).get("style") === "fintech-fonts";
+  const isFintechFonts =
+    new URLSearchParams(location.search).get("style") === "fintech-fonts";
 
   if (isNewProspect) {
     // No data for new prospect
@@ -821,7 +822,9 @@ export default function Dashboard() {
   };
 
   return (
-    <div className={`${isFintechFonts ? "fintech-fonts" : ""} flex-1 bg-gray-50 p-6 overflow-auto`}>
+    <div
+      className={`${isFintechFonts ? "fintech-fonts" : ""} flex-1 bg-gray-50 p-6 overflow-auto`}
+    >
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Row 1: Financial Information - Horizontal Strip */}
         <div
@@ -918,7 +921,9 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Total Due
                     </div>
-                    <div className="text-xl font-bold text-gray-800 font-monoid">$275</div>
+                    <div className="text-xl font-bold text-gray-800 font-monoid">
+                      $275
+                    </div>
                     <div className="text-xs text-gray-500 mt-1">
                       <p>Current Premium Due (YTD)</p>
                     </div>
@@ -928,7 +933,9 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Outstanding Balance
                     </div>
-                    <div className="text-xl font-bold text-gray-800 font-monoid">$190</div>
+                    <div className="text-xl font-bold text-gray-800 font-monoid">
+                      $190
+                    </div>
                     <div className="text-xs text-gray-500 mt-1">
                       <p>Outstanding Balance (after credits)</p>
                     </div>
@@ -964,7 +971,12 @@ export default function Dashboard() {
                   <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                     {Math.min(selectedActivities.length, 4)}
                   </Badge>
-                  <span className="text-[11px] md:text-xs text-gray-500">of {Math.min(selectedActivities.length, 4) === 0 ? 0 : TILE_TOTAL}</span>
+                  <span className="text-[11px] md:text-xs text-gray-500">
+                    of{" "}
+                    {Math.min(selectedActivities.length, 4) === 0
+                      ? 0
+                      : TILE_TOTAL}
+                  </span>
                 </div>
                 <div className="flex items-center">
                   <Button
@@ -1060,7 +1072,9 @@ export default function Dashboard() {
                   <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                     {openDiaries.length}
                   </Badge>
-                  <span className="text-[11px] md:text-xs text-gray-500">of {openDiaries.length === 0 ? 0 : TILE_TOTAL}</span>
+                  <span className="text-[11px] md:text-xs text-gray-500">
+                    of {openDiaries.length === 0 ? 0 : TILE_TOTAL}
+                  </span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Button
@@ -1247,7 +1261,9 @@ export default function Dashboard() {
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {filteredPolicies.length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {filteredPolicies.length === 0 ? 0 : TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">
+                      of {filteredPolicies.length === 0 ? 0 : TILE_TOTAL}
+                    </span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1383,7 +1399,9 @@ export default function Dashboard() {
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {filteredSubmissions.length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {filteredSubmissions.length === 0 ? 0 : TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">
+                      of {filteredSubmissions.length === 0 ? 0 : TILE_TOTAL}
+                    </span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1493,7 +1511,16 @@ export default function Dashboard() {
                             (c) => c.status === "Open" || c.status === "Reopen",
                           ).length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {(isShawn ? 4 : filteredClaims.filter((c) => c.status === "Open" || c.status === "Reopen").length) === 0 ? 0 : TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">
+                      of{" "}
+                      {(isShawn
+                        ? 4
+                        : filteredClaims.filter(
+                            (c) => c.status === "Open" || c.status === "Reopen",
+                          ).length) === 0
+                        ? 0
+                        : TILE_TOTAL}
+                    </span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1741,7 +1768,9 @@ export default function Dashboard() {
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {filteredSubmissions.length}
                     </Badge>
-                    <span className="text-[11px] md:text-xs text-gray-500">of {filteredSubmissions.length === 0 ? 0 : TILE_TOTAL}</span>
+                    <span className="text-[11px] md:text-xs text-gray-500">
+                      of {filteredSubmissions.length === 0 ? 0 : TILE_TOTAL}
+                    </span>
                   </div>
                   <div className="flex items-center">
                     <Button

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -749,6 +749,8 @@ export default function Dashboard() {
       claimsStatusFilter.includes(claim.status),
   );
 
+  const TILE_TOTAL = 10;
+
   const { profileId } = useParams();
   const isShawn = profileId === "shawn-elkins";
   const isJohn = profileId === "john-wills";
@@ -959,9 +961,10 @@ export default function Dashboard() {
                   <CardTitle className="text-base text-gray-700">
                     Activity Timeline
                   </CardTitle>
-                  <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                    {selectedActivities.length} entries
+                  <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
+                    {Math.min(selectedActivities.length, 4)}
                   </Badge>
+                  <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
                 </div>
                 <div className="flex items-center">
                   <Button
@@ -1054,9 +1057,10 @@ export default function Dashboard() {
                   <CardTitle className="text-base text-gray-700">
                     Diaries
                   </CardTitle>
-                  <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                    {openDiaries.length} open
+                  <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
+                    {openDiaries.length}
                   </Badge>
+                  <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Button
@@ -1240,9 +1244,10 @@ export default function Dashboard() {
                     <CardTitle className="text-base text-gray-700">
                       Policies
                     </CardTitle>
-                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                      {filteredPolicies.length} policies
+                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
+                      {filteredPolicies.length}
                     </Badge>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1375,9 +1380,10 @@ export default function Dashboard() {
                     <CardTitle className="text-base text-gray-700">
                       Submissions
                     </CardTitle>
-                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                      {filteredSubmissions.length} submissions
+                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
+                      {filteredSubmissions.length}
                     </Badge>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1480,13 +1486,14 @@ export default function Dashboard() {
                     <CardTitle className="text-base text-gray-700">
                       {isShawn ? "Claims & Incidents" : "Claims"}
                     </CardTitle>
-                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
+                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
                       {isShawn
                         ? 4
                         : filteredClaims.filter(
                             (c) => c.status === "Open" || c.status === "Reopen",
-                          ).length} {isShawn ? "items" : "open"}
+                          ).length}
                     </Badge>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button
@@ -1731,9 +1738,10 @@ export default function Dashboard() {
                     <CardTitle className="text-base text-gray-700">
                       Submissions
                     </CardTitle>
-                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                      {filteredSubmissions.length} submissions
+                    <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-gray-100 text-gray-700 border-gray-200">
+                      {filteredSubmissions.length}
                     </Badge>
+                    <span className="text-[11px] md:text-xs text-gray-500">of {TILE_TOTAL}</span>
                   </div>
                   <div className="flex items-center">
                     <Button

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -754,6 +754,8 @@ export default function Dashboard() {
   const isJohn = profileId === "john-wills";
   const isNewProspect = profileId === "josh-fernandes";
   const hideFinancial = isJohn || isShawn;
+  const location = useLocation();
+  const isFintechFonts = new URLSearchParams(location.search).get("style") === "fintech-fonts";
 
   if (isNewProspect) {
     // No data for new prospect
@@ -817,7 +819,7 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="flex-1 bg-gray-50 p-6 overflow-auto">
+    <div className={`${isFintechFonts ? "fintech-fonts" : ""} flex-1 bg-gray-50 p-6 overflow-auto`}>
       <div className="max-w-7xl mx-auto space-y-6">
         {/* Row 1: Financial Information - Horizontal Strip */}
         <div
@@ -1020,7 +1022,7 @@ export default function Dashboard() {
                             <TableCell className="text-sm py-2 text-gray-700">
                               {activity.type}
                             </TableCell>
-                            <TableCell className="text-sm py-2 text-gray-700 whitespace-nowrap">
+                            <TableCell className="text-sm py-2 text-gray-700 whitespace-nowrap font-monoid">
                               {normalizeFileTag(activity.file, counters)}
                             </TableCell>
                             <TableCell className="text-sm py-2 text-gray-600">
@@ -1324,7 +1326,7 @@ export default function Dashboard() {
                           }}
                         >
                           <TableCell className="py-2">
-                            <span className="text-sm font-medium text-gray-800">
+                            <span className="text-sm font-medium text-gray-800 font-monoid">
                               {shortenAfterDash(policy.policy)}
                             </span>
                           </TableCell>
@@ -1340,10 +1342,10 @@ export default function Dashboard() {
                           <TableCell className="text-sm py-2 text-gray-700 whitespace-nowrap">
                             {policy.endDate}
                           </TableCell>
-                          <TableCell className="text-sm py-2 text-gray-700 font-semibold">
+                          <TableCell className="text-sm py-2 text-gray-700 font-semibold font-monoid">
                             {policy.premiumDue}
                           </TableCell>
-                          <TableCell className="text-sm py-2 text-gray-700 font-semibold">
+                          <TableCell className="text-sm py-2 text-gray-700 font-semibold font-monoid">
                             {policy.premiumPaid}
                           </TableCell>
                         </TableRow>
@@ -1439,7 +1441,7 @@ export default function Dashboard() {
                             );
                           }}
                         >
-                          <TableCell className="text-sm font-medium py-2 text-gray-800">
+                          <TableCell className="text-sm font-medium py-2 text-gray-800 font-monoid">
                             {shortenAfterDash(submission.id)}
                           </TableCell>
                           <TableCell className="text-sm py-2 text-gray-700">
@@ -1672,7 +1674,7 @@ export default function Dashboard() {
                                   );
                                 }}
                               >
-                                <TableCell className="text-sm font-medium py-2 text-gray-800">
+                                <TableCell className="text-sm font-medium py-2 text-gray-800 font-monoid">
                                   {claim.claimNumber}
                                 </TableCell>
                                 <TableCell className="py-2">
@@ -1681,16 +1683,16 @@ export default function Dashboard() {
                                 <TableCell className="text-sm py-2 text-gray-700 w-24 whitespace-nowrap">
                                   {claim.date}
                                 </TableCell>
-                                <TableCell className="text-sm py-2 text-gray-700">
+                                <TableCell className="text-sm py-2 text-gray-700 font-monoid">
                                   {claim.incurred}
                                 </TableCell>
-                                <TableCell className="text-sm py-2 text-gray-700">
+                                <TableCell className="text-sm py-2 text-gray-700 font-monoid">
                                   {claim.reserves}
                                 </TableCell>
-                                <TableCell className="text-sm py-2 text-gray-700">
+                                <TableCell className="text-sm py-2 text-gray-700 font-monoid">
                                   {claim.paid}
                                 </TableCell>
-                                <TableCell className="text-sm py-2 text-gray-700">
+                                <TableCell className="text-sm py-2 text-gray-700 font-monoid">
                                   {claim.recoveries}
                                 </TableCell>
                               </TableRow>
@@ -1805,7 +1807,7 @@ export default function Dashboard() {
                             );
                           }}
                         >
-                          <TableCell className="text-sm font-medium py-2 text-gray-800">
+                          <TableCell className="text-sm font-medium py-2 text-gray-800 font-monoid">
                             {shortenAfterDash(submission.id)}
                           </TableCell>
                           <TableCell className="text-sm py-2 text-gray-700">

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -865,7 +865,7 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Total Incurred (This Claimant)
                     </div>
-                    <div className="text-xl font-bold text-gray-800">
+                    <div className="text-xl font-bold text-gray-800 font-monoid">
                       $11,800.00
                     </div>
                     <Progress value={21} className="h-2 mt-2" />
@@ -877,7 +877,7 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Outstanding Reserves
                     </div>
-                    <div className="text-xl font-bold text-gray-800">
+                    <div className="text-xl font-bold text-gray-800 font-monoid">
                       $7,250.00
                     </div>
                     <Progress value={60} className="h-2 mt-2" />
@@ -889,7 +889,7 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Amount Paid
                     </div>
-                    <div className="text-xl font-bold text-gray-800">
+                    <div className="text-xl font-bold text-gray-800 font-monoid">
                       $5,200.00
                     </div>
                     <Progress value={40} className="h-2 mt-2" />
@@ -904,7 +904,7 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Amount Paid
                     </div>
-                    <div className="text-xl font-bold text-gray-800">
+                    <div className="text-xl font-bold text-gray-800 font-monoid">
                       $8,460
                     </div>
                     <div className="text-xs text-gray-500 mt-1">
@@ -916,7 +916,7 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Total Due
                     </div>
-                    <div className="text-xl font-bold text-gray-800">$275</div>
+                    <div className="text-xl font-bold text-gray-800 font-monoid">$275</div>
                     <div className="text-xs text-gray-500 mt-1">
                       <p>Current Premium Due (YTD)</p>
                     </div>
@@ -926,7 +926,7 @@ export default function Dashboard() {
                     <div className="text-xs text-gray-600 mb-1 font-medium">
                       Outstanding Balance
                     </div>
-                    <div className="text-xl font-bold text-gray-800">$190</div>
+                    <div className="text-xl font-bold text-gray-800 font-monoid">$190</div>
                     <div className="text-xs text-gray-500 mt-1">
                       <p>Outstanding Balance (after credits)</p>
                     </div>

--- a/client/pages/Dashboard.tsx
+++ b/client/pages/Dashboard.tsx
@@ -958,7 +958,7 @@ export default function Dashboard() {
                     Activity Timeline
                   </CardTitle>
                   <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                    {selectedActivities.length}
+                    {selectedActivities.length} entries
                   </Badge>
                 </div>
                 <div className="flex items-center">
@@ -1053,7 +1053,7 @@ export default function Dashboard() {
                     Diaries
                   </CardTitle>
                   <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                    {openDiaries.length}
+                    {openDiaries.length} open
                   </Badge>
                 </div>
                 <div className="flex items-center gap-2">
@@ -1239,7 +1239,7 @@ export default function Dashboard() {
                       Policies
                     </CardTitle>
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                      {filteredPolicies.length}
+                      {filteredPolicies.length} policies
                     </Badge>
                   </div>
                   <div className="flex items-center">
@@ -1374,7 +1374,7 @@ export default function Dashboard() {
                       Submissions
                     </CardTitle>
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                      {filteredSubmissions.length}
+                      {filteredSubmissions.length} submissions
                     </Badge>
                   </div>
                   <div className="flex items-center">
@@ -1483,7 +1483,7 @@ export default function Dashboard() {
                         ? 4
                         : filteredClaims.filter(
                             (c) => c.status === "Open" || c.status === "Reopen",
-                          ).length}
+                          ).length} {isShawn ? "items" : "open"}
                     </Badge>
                   </div>
                   <div className="flex items-center">
@@ -1730,7 +1730,7 @@ export default function Dashboard() {
                       Submissions
                     </CardTitle>
                     <Badge className="ml-1 px-2 py-0.5 text-[11px] md:text-xs bg-blue-100 text-blue-700 border-blue-200">
-                      {filteredSubmissions.length}
+                      {filteredSubmissions.length} submissions
                     </Badge>
                   </div>
                   <div className="flex items-center">

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
       href="https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@300;400;600;700;900&display=swap"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lato:wght@700&family=Open+Sans:wght@400&family=Inconsolata:wght@400&display=swap"
+      rel="stylesheet"
+    />
   </head>
 
   <body>


### PR DESCRIPTION
## Purpose

Based on user feedback, this PR implements two key improvements:
1. **Font styling**: Applied new fintech fonts across all headings, tiles, and UI elements as requested
2. **Counter format**: Updated tile counters to display as "X of Y" format (e.g., "5 of 10") with the count shown in a light grey bubble, and handle zero entries as "0 of 0"

## Code changes

- **Font integration**: Added Google Fonts for Lato, Open Sans, and Inconsolata to support the new fintech styling
- **Conditional font application**: Implemented URL parameter-based font switching (`?style=fintech-fonts`) to enable fintech fonts across the application
- **Typography classes**: Added `font-header` and `font-monoid` classes to headers, sidebar elements, and data tables for consistent styling
- **Counter display**: Modified all tile badges to show count in grey styling with "of X" text format, where X is either 0 (for empty tiles) or a constant total (10/15)
- **Navigation enhancement**: Added "Fintech Fonts sample" link to sidebar for easy testing of the new styling

The changes ensure consistent application of the fintech font family while maintaining the existing functionality and improving the visual presentation of data counters.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fe99c1890cb14b5191c2a5663a118e7b/nova-verse)

👀 [Preview Link](https://fe99c1890cb14b5191c2a5663a118e7b-nova-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fe99c1890cb14b5191c2a5663a118e7b</projectId>-->
<!--<branchName>nova-verse</branchName>-->